### PR TITLE
add migrations with db-migrate

### DIFF
--- a/database.json
+++ b/database.json
@@ -1,0 +1,9 @@
+{
+  "dev": {
+    "host": "localhost",
+    "user": "root",
+    "database": "Giftr",
+    "driver": "mysql",
+    "multipleStatements": true
+  }
+}

--- a/migrations/20180530191645-Products.js
+++ b/migrations/20180530191645-Products.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db, callback) {
+  db.createTable('Products', {
+    id: { type: 'int', primaryKey: true },
+    title: 'string',
+    description: 'string',
+  }, callback);
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20180530192313-Users.js
+++ b/migrations/20180530192313-Users.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db, callback) {
+  db.createTable('Users', {
+    id: { type: 'int', primaryKey: true },
+    firstName: 'string',
+    lastName: 'string',
+    email: 'string'
+  }, callback);
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20180530192343-Recipients.js
+++ b/migrations/20180530192343-Recipients.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db, callback) {
+  db.createTable('Recipients', {
+    id: { type: 'int', primaryKey: true },
+    firstName: 'string',
+    lastName: 'string',
+    email: 'string'
+  }, callback);
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20180530192349-Purchases.js
+++ b/migrations/20180530192349-Purchases.js
@@ -1,0 +1,66 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db, callback) {
+  db.createTable('Purchases', {
+    id: { type: 'int', primaryKey: true },
+    product_id: {
+      type: 'int',
+      foreignKey: {
+        name: 'product_id_fk',
+        table: 'Products',
+        rules: {
+          onDelete: 'CASCADE',
+          onUpdate: 'RESTRICT'
+        },
+        mapping: 'id'
+      }
+    },
+    user_id: {
+      type: 'int',
+      foreignKey: {
+        name: 'user_id_fk',
+        table: 'Users',
+        rules: {
+          onDelete: 'CASCADE',
+          onUpdate: 'RESTRICT'
+        },
+        mapping: 'id'
+      }
+    },
+    recipient_id: {
+      type: 'int',
+      foreignKey: {
+        name: 'recipient_id_fk',
+        table: 'Recipients',
+        rules: {
+          onDelete: 'CASCADE',
+          onUpdate: 'RESTRICT'
+        },
+        mapping: 'id'
+      }
+    }
+  }, callback);
+  return null;
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "author": "Lian Thompson",
     "license": "MIT",
     "scripts": {
+        "postinstall": "cd client && npm install",
         "client": "cd client && npm start",
         "server": "nodemon server.js",
         "dev": "concurrently --kill-others-on-fail \"npm run server\" \"npm run client\""
@@ -12,6 +13,7 @@
     "dependencies": {
         "axios": "^0.18.0",
         "cors": "^2.8.4",
+        "db-migrate": "^0.11.1",
         "dotenv": "^5.0.1",
         "express": "^4.16.2",
         "material-ui": "^0.20.1",

--- a/server.js
+++ b/server.js
@@ -2,8 +2,8 @@ const express = require('express');
 const cors = require('cors');
 const app = express();
 const request = require('request');
-// const port = 3000;
-// change to 3001 for create-react-app 
+const port = 4000;
+// change to 3001 for create-react-app
 const mysql = require('mysql');
 require('dotenv').load();
 // create authO developer account, apply sample code to here, create sample link
@@ -24,7 +24,7 @@ connection.connect(err => {
     if(err) {
         return err;
     }
-    console.log(connection);
+    // console.log(connection);
 });
 
 app.use(cors({ credentials: true, origin: true }));
@@ -60,4 +60,4 @@ app.get('/', (req, res) => {
     // });
  );
 
-app.listen(4000, () => console.log(`Listening on port 4000`));
+app.listen(port, () => console.log(`Listening on port ${port}`));


### PR DESCRIPTION
I got annoyed with manually making the tables for the database, so I added a [node module](https://db-migrate.readthedocs.io/en/latest/Getting%20Started/usage/) for migrations and wrote one migration per table.  You should modify your readme to give instructions on how to run the migrations rather than instructing the reader to create them manually.